### PR TITLE
Fix events camelcase

### DIFF
--- a/src/components/FormWizard.vue
+++ b/src/components/FormWizard.vue
@@ -76,7 +76,7 @@ export default {
         previousTab(){
             this._switchTab(this.currentTab - 1);
 
-            this.$emit('onPreviousStep'); 
+            this.$emit('on-previous-step'); 
         },
 
         nextTab(){
@@ -86,7 +86,7 @@ export default {
 
             this._switchTab(this.currentTab + 1);    
 
-            this.$emit('onNextStep');          
+            this.$emit('on-next-step');          
               
         },
 
@@ -101,7 +101,7 @@ export default {
            this.submitSuccess = false;
            this.storeState.v.$reset();
 
-           this.$emit('onReset');
+           this.$emit('on-reset');
         },
 
         changeStatus(){
@@ -131,7 +131,7 @@ export default {
         onSubmit(){
             if(this._validateCurrentTab() === false)
                 return;
-            this.$emit('onComplete');
+            this.$emit('on-complete');
         },
 
         _switchTab(index){


### PR DESCRIPTION
This commit fix events camelcase names, that stop working with message:

```
Vue tip]: Event "oncomplete" is emitted in component <FormWizard> but the handler is registered for "onComplete". Note that HTML attributes are case-insensitive and you cannot use v-on to listen to camelCase events when using in-DOM templates. You should probably use "on-complete" instead of "onComplete".
```